### PR TITLE
remove stdin=subprocess.PIPE / fix ansible password prompt

### DIFF
--- a/nsbl/nsbl.py
+++ b/nsbl/nsbl.py
@@ -594,7 +594,7 @@ class NsblRunner(object):
             #     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
             script = parameters['run_playbooks_script']
-            proc = subprocess.Popen(script, stdout=subprocess.PIPE, stderr=sys.stdout.fileno(), stdin=subprocess.PIPE, shell=True, env=run_env, preexec_fn=os.setsid)
+            proc = subprocess.Popen(script, stdout=subprocess.PIPE, stderr=sys.stdout.fileno(), shell=True, env=run_env, preexec_fn=os.setsid)
 
 
             with CursorOff():


### PR DESCRIPTION
From a fresh freckles installation, I encounter a bug when freckles (more precisely, ansible runned by nsbl) issues a warn about stdin. After this warning, it is impossible to validate password prompt; ansible waits forever for password input despite input validation.

It appears that nsbl wrongly uses stdin=subprocess.PIPE, so that ansible is not connected to terminal stdin. As no binding is done between terminal stdin and ansible subprocess stdin, process hangs.

My fix remove stdin=subprocess.PIPE, so that ansible is directly connected to parent (terminal) stdin. as popen.stdin is not used in nsbl, I suppose this fix does not trigger any regression.

Proposed commit message:

stdin=subprocess.PIPE allow parent process to control stdin; but we need
here to provide direct stdin processing by subprocess.

Before fix (warning + password is printed in terminal as it is typed and no
possibility to validate password prompt, process hangs)

```
~/.local/opt/conda/envs/inaugurate/lib/python2.7/getpass.py:83: GetPassWarning: Can not control echo on the terminal.
  passwd = fallback_getpass(prompt, stream)
Warning: Password input may be echoed.
SUDO password: xxxx
```

After fix (password can be typed and retrieved by ansible, not printed
in terminal):

```
SUDO password:
```