### PR TITLE
missing symbol in nsbl.py

### DIFF
--- a/nsbl/nsbl.py
+++ b/nsbl/nsbl.py
@@ -8,6 +8,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import time
 from datetime import datetime
 
 import click


### PR DESCRIPTION
time is not imported, to time.sleep(.5) fails when proc.poll() not None (this explains that bug is not always triggered, as process has a chance to end before poll testing).

Stack example:
```
Traceback (most recent call last):
  File "/home/vagrant/.local/bin/frecklecute", line 11, in <module>
    sys.exit(cli())
  File "/home/vagrant/.local/inaugurate/conda/envs/inaugurate/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/vagrant/.local/inaugurate/conda/envs/inaugurate/lib/python2.7/site-packages/click/core.py", line 696, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/home/vagrant/.local/inaugurate/conda/envs/inaugurate/lib/python2.7/site-packages/click/core.py", line 621, in make_context
    self.parse_args(ctx, args)
  File "/home/vagrant/.local/inaugurate/conda/envs/inaugurate/lib/python2.7/site-packages/click/core.py", line 1018, in parse_args
    rest = Command.parse_args(self, ctx, args)
  File "/home/vagrant/.local/inaugurate/conda/envs/inaugurate/lib/python2.7/site-packages/click/core.py", line 880, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/home/vagrant/.local/inaugurate/conda/envs/inaugurate/lib/python2.7/site-packages/click/core.py", line 1404, in handle_parse_result
    self.callback, ctx, self, value)
  File "/home/vagrant/.local/inaugurate/conda/envs/inaugurate/lib/python2.7/site-packages/click/core.py", line 78, in invoke_param_callback
    return callback(ctx, param, value)
  File "/home/vagrant/.local/inaugurate/conda/envs/inaugurate/lib/python2.7/site-packages/freckles/utils.py", line 384, in download_extra_repos
    create_and_run_nsbl_runner(task_config, task_metadata={}, output_format=output, ask_become_pass=False)
  File "/home/vagrant/.local/inaugurate/conda/envs/inaugurate/lib/python2.7/site-packages/freckles/utils.py", line 672, in create_and_run_nsbl_runner
    display_ignore_tasks=ignore_task_strings, pre_run_callback=pre_run_callback)
  File "/home/vagrant/.local/inaugurate/conda/envs/inaugurate/lib/python2.7/site-packages/nsbl/nsbl.py", line 676, in run
    time.sleep(0.5)
NameError: global name 'time' is not defined
```