### PR TITLE
fix broken output when msg is a non-string value

### DIFF
--- a/nsbl/output.py
+++ b/nsbl/output.py
@@ -2,11 +2,13 @@
 
 import json
 import logging
+import pprint
 import subprocess
 import sys
 
 import click
 import cursor
+from six import string_types
 
 from .defaults import *
 
@@ -210,9 +212,9 @@ class NsblLogCallbackAdapter(object):
         action = details.get('action', self.last_action)
         ansible_task_name = details.get('name', None)
 
+        if not isinstance(msg, string_types):
+            msg = pprint.pformat(msg)
         if msg:
-            # if isinstance(msg, dict):
-            # raise Exception(msg)
             msg = msg.encode(ENCODING, errors='replace').strip()
         if msg:
             self.msgs.append(msg)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ requirements = [
     'cookiecutter==1.5.1',
     'ansible==2.4.1.0',
     'frkl==0.1.0',
-    'cursor>=1.1.0'
+    'cursor>=1.1.0',
+    'six==1.11.0'
 ]
 
 test_requirements = [


### PR DESCRIPTION
if msg (json output attribute) is not a string, frecklecute commands
fails with ``AttributeError: 'list' object has no attribute 'encode'``