### PR TITLE
Sudo password(less) detection fix

### DIFF
--- a/nsbl/env_creator.py
+++ b/nsbl/env_creator.py
@@ -22,7 +22,7 @@ def can_passwordless_sudo():
 
     FNULL = open(os.devnull, 'w')
     # use -k to ignore any existing sudo token
-    p = subprocess.Popen('sudo -k -n ls', shell=True, stdout=FNULL, stderr=subprocess.STDOUT, close_fds=True)
+    p = subprocess.Popen('sudo -k -n true', shell=True, stdout=FNULL, stderr=subprocess.STDOUT, close_fds=True)
     r = p.wait()
     return r == 0
 

--- a/nsbl/env_creator.py
+++ b/nsbl/env_creator.py
@@ -21,7 +21,8 @@ def can_passwordless_sudo():
     """Checks if the user can use passwordless sudo on this host."""
 
     FNULL = open(os.devnull, 'w')
-    p = subprocess.Popen('sudo -n ls', shell=True, stdout=FNULL, stderr=subprocess.STDOUT, close_fds=True)
+    # use -k to ignore any existing sudo token
+    p = subprocess.Popen('sudo -k -n ls', shell=True, stdout=FNULL, stderr=subprocess.STDOUT, close_fds=True)
     r = p.wait()
     return r == 0
 


### PR DESCRIPTION
Currently, sudo password detection is not accurate as it depends on the potential existence of a sudo token. If detection is done when user already used sudo and entered its password, and token had not already expired, password detection decides that sudo is passwordless.

How to exhibit the behavior:

* configure sudo to need a password
* use this frecklecutable script

``` yaml
tasks:
  - shell: whoami
meta:
  use_become: true
vars:
  become: true
  become_user: root
```
* run the script: sudo is prompted by frecklecutable
* run ``sudo true``; sudo prompt your password
* run again frecklecutable: sudo password is no longer prompted

It breaks frecklecutable script execution if sudo token expires during script execution. It happens if script involves long running command (longer than sudo token timeout).

This fix use ``-k`` flag to ignore current sudo token, so that ``can_passwordless_sudo`` result is now accurate. As ``-k`` flag used with a command does not invalidate sudo token, it does not trigger any side-effect.

Command used with sudo is also modified: ``true`` instead of ``ls`` as it is a more *neutral* command.