### PR TITLE
fix on previous PR #59

### DIFF
--- a/nsbl/nsbl.py
+++ b/nsbl/nsbl.py
@@ -41,7 +41,8 @@ def can_passwordless_sudo():
         return True
 
     FNULL = open(os.devnull, 'w')
-    p = subprocess.Popen('sudo -n ls', shell=True, stdout=FNULL, stderr=subprocess.STDOUT, close_fds=True)
+    # use -k to ignore any existing sudo token
+    p = subprocess.Popen('sudo -k -n true', shell=True, stdout=FNULL, stderr=subprocess.STDOUT, close_fds=True)
     r = p.wait()
     return r == 0
 


### PR DESCRIPTION
Sorry, I just see that my previous fix was incomplete. Surely an error when I report my fix from running code to my git repo, as I fix a duplicated code.

Not sure if duplicated code is dead code, or part of a public API unused by freckles. Let me know if you want I rework PR to eliminate duplicate code.

Commit message:

fixed code is duplicated. Previous PR only fix one occurence, and
probably the wrong one as I find no occurence of env_creator (previously
fixed file) in nsbl or freckles.

I surely wrongly reported fix from my working env to my git repository.

I test this fix, and it ensures the following and correct behavior:

* if passwordless sudo, no prompt for sudo password
* if password sudo, prompt for password even if a sudo token is
  available and not expired, so that long freckles run do not fail on
  token timeout.

Before this fix, password is not prompted if a token is available and
not expired.